### PR TITLE
Refactor AbstractDescriptor

### DIFF
--- a/src/Descriptor/IDescriptor.cs
+++ b/src/Descriptor/IDescriptor.cs
@@ -2,8 +2,8 @@
 {
     public interface IDescriptor
     {
-        string Description { get; }
-        string Name { get; }
-        string Type { get; }
+        string Description { get; set; }
+        string Name { get; set; }
+        string Type { get; set; }
     }
 }


### PR DESCRIPTION
New behavior extracts logic for converting an Expression into MethodInfo.
Previous behavior bundled this into the same method which is called for adding action definitions.
A problem exists, however, since multiple action methods may need to be defined based on documented method signature.