### PR TITLE
Fix company name within assembly info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Descriptor
+# Descriptor [![Build Status](https://travis-ci.org/ritterim/descriptor.svg?branch=master)](https://travis-ci.org/ritterim/descriptor)
 
 Provides a fluent interface for documenting code and formatting output.
 

--- a/src/Descriptor/Properties/AssemblyInfo.cs
+++ b/src/Descriptor/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Descriptor")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("RimDev Insurance Marketing, Inc.")]
+[assembly: AssemblyCompany("Ritter Insurance Marketing, Inc.")]
 [assembly: AssemblyProduct("Descriptor")]
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]


### PR DESCRIPTION
Previous version was part of namespace refactor.
I used a global find/replace.

Committing directly to `master`... :open_mouth: 