### PR TITLE
Add assembly scanner

### DIFF
--- a/src/Descriptor/AssemblyScanner.cs
+++ b/src/Descriptor/AssemblyScanner.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using RimDev.Descriptor.Generic;
+
+namespace RimDev.Descriptor
+{
+    public class AssemblyScanner : IEnumerable<IDescriptor<IDescriptorContainer>>
+    {
+        public AssemblyScanner(IEnumerable<Type> scannerTypes)
+        {
+            this.scannerTypes = scannerTypes;
+        }
+
+        private readonly IEnumerable<Type> scannerTypes;
+
+        public static AssemblyScanner FindDescriptorsInAssembly(Assembly assembly)
+        {
+            return new AssemblyScanner(assembly.GetExportedTypes());
+        }
+
+        public static AssemblyScanner FindDescriptorsInAssemblyContaining<T>()
+        {
+            return FindDescriptorsInAssembly(typeof(T).Assembly);
+        }
+
+        private IEnumerable<IDescriptor<IDescriptorContainer>> Execute()
+        {
+            var scannerInstances = from scannerType in scannerTypes
+                        let scannerInterfaces = scannerType.GetInterfaces()
+                        let genericScannerInterfaces = scannerInterfaces.Where(
+                            i => i.IsGenericType
+                                && i.GetGenericTypeDefinition() == typeof(IDescriptor<>))
+                        let matchingScannerInterface = genericScannerInterfaces.FirstOrDefault()
+                        where matchingScannerInterface != null
+                        select Activator.CreateInstance(scannerType) as IDescriptor<IDescriptorContainer>;
+
+            return scannerInstances;
+        }
+
+        public void ForEach(Action<IDescriptor<IDescriptorContainer>> action)
+        {
+            foreach (var result in this)
+            {
+                action(result);
+            }
+        }
+
+        public IEnumerator<IDescriptor<IDescriptorContainer>> GetEnumerator()
+        {
+            return Execute().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/Descriptor/Descriptor.csproj
+++ b/src/Descriptor/Descriptor.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AssemblyScanner.cs" />
     <Compile Include="Generic\AbstractDescriptor`1.cs" />
     <Compile Include="Descriptor.cs" />
     <Compile Include="Generic\HttpDescriptorContainer`1.cs" />


### PR DESCRIPTION
The current version is modeled after the FluentValidation-version (https://github.com/JeremySkinner/FluentValidation/blob/f0b19cf766a8258fc84e696329dbf2b1a1f113bd/src/FluentValidation/AssemblyScanner.cs)
This will allow a user to easily extract documented-code instances within an assembly. The next step is to feed into a formatter for output.

``` csharp
var formatter = new TodoFormatter();

AssemblyScanner.FindDescriptorsInAssemblyContaining<Program>()
    .ForEach(x => {
        formatter.AddDescriptor(x);
    });
```