### PR TITLE
Add descriptor helpers and updates for AssemblyScanner

### DIFF
--- a/src/Descriptor/Descriptor.cs
+++ b/src/Descriptor/Descriptor.cs
@@ -85,5 +85,26 @@ namespace RimDev.Descriptor
                 return new Action<object>(x => action((T)x));
             }
         }
+
+        public Descriptor<TClass> SetDescription(string description)
+        {
+            Instance.Description = description;
+
+            return this;
+        }
+
+        public Descriptor<TClass> SetName(string name)
+        {
+            Instance.Name = name;
+
+            return this;
+        }
+
+        public Descriptor<TClass> SetType(string type)
+        {
+            Instance.Type = type;
+
+            return this;
+        }
     }
 }

--- a/src/Descriptor/Generic/AbstractDescriptor`1.cs
+++ b/src/Descriptor/Generic/AbstractDescriptor`1.cs
@@ -5,9 +5,9 @@ using RimDev.Descriptor.Helpers;
 
 namespace RimDev.Descriptor.Generic
 {
-    public abstract class AbstractDescriptor<TClass, TInstanceContainer>
+    public abstract class AbstractDescriptor<TClass, TInstanceContainer> : IDescriptor<TInstanceContainer>
         where TClass : class, new()
-        where TInstanceContainer : class, new()
+        where TInstanceContainer : class, IDescriptorContainer, new()
     {
         public AbstractDescriptor()
         {
@@ -15,7 +15,7 @@ namespace RimDev.Descriptor.Generic
             Methods = new List<object>();
         }
 
-        protected TInstanceContainer Instance { get; private set; }
+        public TInstanceContainer Instance { get; private set; }
         protected ICollection<object> Methods { get; private set; }
 
         protected MemberInfo ExtractMethodInfoFromUnaryExpression(

--- a/src/Descriptor/Generic/DescriptorContainer`1.cs
+++ b/src/Descriptor/Generic/DescriptorContainer`1.cs
@@ -1,6 +1,6 @@
 ﻿namespace RimDev.Descriptor.Generic
 {
-    public class DescriptorContainer<T>
+    public class DescriptorContainer<T> : IDescriptorContainer
     {
         public virtual string Description { get; set; }
         public virtual string Name { get; set; }

--- a/src/Descriptor/HttpDescriptor.cs
+++ b/src/Descriptor/HttpDescriptor.cs
@@ -7,6 +7,14 @@ namespace RimDev.Descriptor
     public class HttpDescriptor<TClass> : Descriptor<TClass>
         where TClass : class, new()
     {
+        public HttpDescriptor(
+            string name = null,
+            string description = null,
+            string type = null)
+            :base(name, description, type)
+        {
+        }
+
         public HttpDescriptor<TClass> Action<TModel>(
             Expression<Func<TClass, Func<TModel, object>>> method,
             string description = null,
@@ -32,6 +40,27 @@ namespace RimDev.Descriptor
                     ?? "n/a";
 
             Methods.Add(methodContainer);
+
+            return this;
+        }
+
+        public new HttpDescriptor<TClass> SetDescription(string description)
+        {
+            base.SetDescription(description);
+
+            return this;
+        }
+
+        public new HttpDescriptor<TClass> SetName(string name)
+        {
+            base.SetName(name);
+
+            return this;
+        }
+
+        public new HttpDescriptor<TClass> SetType(string type)
+        {
+            base.SetType(type);
 
             return this;
         }


### PR DESCRIPTION
Related to https://github.com/ritterim/descriptor/pull/10 and https://github.com/ritterim/descriptor/pull/11, descriptor instances can now be used with AssemblyScanner.

Also added helpers when using descriptor-instances to provider more fluent interface between setting name and description properties with actions.