### PR TITLE
Move HTTP descriptor into its own project

### DIFF
--- a/Descriptor.sln
+++ b/Descriptor.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B344
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Descriptor.Console", "samples\Descriptor.Console\Descriptor.Console.csproj", "{931322DF-E998-4A14-8523-93B51857538E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Descriptor.Http", "src\Descriptor.Http\Descriptor.Http.csproj", "{6374A091-F20C-4BCB-BAE0-C2F55002A423}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,10 @@ Global
 		{931322DF-E998-4A14-8523-93B51857538E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{931322DF-E998-4A14-8523-93B51857538E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{931322DF-E998-4A14-8523-93B51857538E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6374A091-F20C-4BCB-BAE0-C2F55002A423}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6374A091-F20C-4BCB-BAE0-C2F55002A423}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6374A091-F20C-4BCB-BAE0-C2F55002A423}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6374A091-F20C-4BCB-BAE0-C2F55002A423}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/samples/Descriptor.Console/Descriptor.Console.csproj
+++ b/samples/Descriptor.Console/Descriptor.Console.csproj
@@ -51,6 +51,10 @@
     <None Include="App.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Descriptor.Http\Descriptor.Http.csproj">
+      <Project>{6374a091-f20c-4bcb-bae0-c2f55002a423}</Project>
+      <Name>Descriptor.Http</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Descriptor\Descriptor.csproj">
       <Project>{09569c4c-7757-4b8e-b286-42e4571ee60b}</Project>
       <Name>Descriptor</Name>

--- a/samples/Descriptor.Console/MathLibraryDescriptor.cs
+++ b/samples/Descriptor.Console/MathLibraryDescriptor.cs
@@ -1,4 +1,6 @@
-﻿namespace RimDev.Descriptor.Console
+﻿using RimDev.Descriptor.Http;
+
+namespace RimDev.Descriptor.Console
 {
     public class MathLibraryDescriptor : Descriptor<MathLibrary>
     {

--- a/src/Descriptor.Http/Descriptor.Http.csproj
+++ b/src/Descriptor.Http/Descriptor.Http.csproj
@@ -4,11 +4,11 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{09569C4C-7757-4B8E-B286-42E4571EE60B}</ProjectGuid>
+    <ProjectGuid>{6374A091-F20C-4BCB-BAE0-C2F55002A423}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>RimDev.Descriptor</RootNamespace>
-    <AssemblyName>RimDev.Descriptor</AssemblyName>
+    <RootNamespace>RimDev.Descriptor.Http</RootNamespace>
+    <AssemblyName>RimDev.Descriptor.Http</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
@@ -39,19 +39,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="AssemblyScanner.cs" />
-    <Compile Include="Generic\AbstractDescriptor`1.cs" />
-    <Compile Include="Descriptor.cs" />
-    <Compile Include="Generic\DescriptorContainer`1.cs" />
-    <Compile Include="Generic\IDescriptor`1.cs">
-      <SubType>Code</SubType>
-    </Compile>
-    <Compile Include="Generic\MethodDescriptorContainer`1.cs" />
-    <Compile Include="Helpers\EnvironmentHelper.cs" />
-    <Compile Include="IDescriptorContainer.cs">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="Generics\HttpDescriptorContainer`1.cs" />
+    <Compile Include="Generics\HttpMethodDescriptorContainer`1.cs" />
+    <Compile Include="HttpDescriptor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Descriptor\Descriptor.csproj">
+      <Project>{09569c4c-7757-4b8e-b286-42e4571ee60b}</Project>
+      <Name>Descriptor</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Descriptor.Http/Generics/HttpDescriptorContainer`1.cs
+++ b/src/Descriptor.Http/Generics/HttpDescriptorContainer`1.cs
@@ -1,4 +1,6 @@
-﻿namespace RimDev.Descriptor.Generic
+﻿using RimDev.Descriptor.Generic;
+
+namespace RimDev.Descriptor.Http.Generic
 {
     public class HttpDescriptorContainer<T> : DescriptorContainer<T>
     {

--- a/src/Descriptor.Http/Generics/HttpMethodDescriptorContainer`1.cs
+++ b/src/Descriptor.Http/Generics/HttpMethodDescriptorContainer`1.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace RimDev.Descriptor.Generic
+namespace RimDev.Descriptor.Http.Generic
 {
     public class HttpMethodDescriptorContainer<T> : HttpDescriptorContainer<T>
     {

--- a/src/Descriptor.Http/HttpDescriptor.cs
+++ b/src/Descriptor.Http/HttpDescriptor.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Linq.Expressions;
-using RimDev.Descriptor.Generic;
+using RimDev.Descriptor.Http.Generic;
 
-namespace RimDev.Descriptor
+namespace RimDev.Descriptor.Http
 {
     public class HttpDescriptor<TClass> : Descriptor<TClass>
         where TClass : class, new()

--- a/src/Descriptor.Http/Properties/AssemblyInfo.cs
+++ b/src/Descriptor.Http/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Descriptor.Http")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Ritter Insurance Marketing, Inc.")]
+[assembly: AssemblyProduct("Descriptor.Http")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cf4f1cf3-3fb0-4f55-ad6d-7a1320e1e37a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
This helps to align an upcoming goal of publishing various NuGets for the project.