### PR TITLE
Add starter formatters

### DIFF
--- a/Descriptor.sln
+++ b/Descriptor.sln
@@ -15,6 +15,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Descriptor.Console", "sampl
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Descriptor.Http", "src\Descriptor.Http\Descriptor.Http.csproj", "{6374A091-F20C-4BCB-BAE0-C2F55002A423}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Descriptor.Formatters.Json", "src\Descriptor.Formatters.Json\Descriptor.Formatters.Json.csproj", "{33165E14-218B-46C7-ADD6-4F91BF36D23D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Descriptor.Formatters", "src\Descriptor.Formatters\Descriptor.Formatters.csproj", "{F46349B3-DD54-4504-976E-354D0799448A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -37,6 +41,14 @@ Global
 		{6374A091-F20C-4BCB-BAE0-C2F55002A423}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6374A091-F20C-4BCB-BAE0-C2F55002A423}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6374A091-F20C-4BCB-BAE0-C2F55002A423}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33165E14-218B-46C7-ADD6-4F91BF36D23D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33165E14-218B-46C7-ADD6-4F91BF36D23D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33165E14-218B-46C7-ADD6-4F91BF36D23D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33165E14-218B-46C7-ADD6-4F91BF36D23D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F46349B3-DD54-4504-976E-354D0799448A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F46349B3-DD54-4504-976E-354D0799448A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F46349B3-DD54-4504-976E-354D0799448A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F46349B3-DD54-4504-976E-354D0799448A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Descriptor.Formatters.Json/Descriptor.Formatters.Json.csproj
+++ b/src/Descriptor.Formatters.Json/Descriptor.Formatters.Json.csproj
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{33165E14-218B-46C7-ADD6-4F91BF36D23D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RimDev.Descriptor.Formatters.Json</RootNamespace>
+    <AssemblyName>RimDev.Descriptor.Formatters.Json</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="JsonFormatter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebApiJsonFormatter.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Descriptor.Formatters\Descriptor.Formatters.csproj">
+      <Project>{f46349b3-dd54-4504-976e-354d0799448a}</Project>
+      <Name>Descriptor.Formatters</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Descriptor\Descriptor.csproj">
+      <Project>{09569c4c-7757-4b8e-b286-42e4571ee60b}</Project>
+      <Name>Descriptor</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Descriptor.Formatters.Json/JsonFormatter.cs
+++ b/src/Descriptor.Formatters.Json/JsonFormatter.cs
@@ -1,0 +1,20 @@
+﻿using Descriptor.Formatters;
+using Newtonsoft.Json;
+
+namespace RimDev.Descriptor.Formatters.Json
+{
+    public class JsonFormatter : AbstractFormatter
+    {
+        public override object Format()
+        {
+            var settings = new JsonSerializerSettings();
+
+            return Format(settings);
+        }
+
+        public virtual object Format(JsonSerializerSettings settings)
+        {
+            return JsonConvert.SerializeObject(descriptors, settings);
+        }
+    }
+}

--- a/src/Descriptor.Formatters.Json/Properties/AssemblyInfo.cs
+++ b/src/Descriptor.Formatters.Json/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Descriptor.Formatters.Json")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Ritter Insurance Marketing, Inc.")]
+[assembly: AssemblyProduct("Descriptor.Formatters.Json")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("76bd6ba6-7e50-4430-948f-700f32233fa3")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Descriptor.Formatters.Json/WebApiJsonFormatter.cs
+++ b/src/Descriptor.Formatters.Json/WebApiJsonFormatter.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace RimDev.Descriptor.Formatters.Json
+{
+    public class WebApiJsonFormatter : JsonFormatter
+    {
+        public override object Format()
+        {
+            var settings = new JsonSerializerSettings()
+            {
+                ContractResolver = new HttpContractResolver(),
+                NullValueHandling = NullValueHandling.Ignore
+            };
+
+            return Format(settings);
+        }
+
+        public class HttpContractResolver : CamelCasePropertyNamesContractResolver
+        {
+            protected override string ResolvePropertyName(string propertyName)
+            {
+                var name = base.ResolvePropertyName(propertyName);
+
+                name = string.Equals(name, "uri", StringComparison.InvariantCultureIgnoreCase) ? "href" : name;
+
+                return name;
+            }
+        }
+    }
+}

--- a/src/Descriptor.Formatters.Json/packages.config
+++ b/src/Descriptor.Formatters.Json/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+</packages>

--- a/src/Descriptor.Formatters/AbstractFormatter.cs
+++ b/src/Descriptor.Formatters/AbstractFormatter.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using RimDev.Descriptor;
+using RimDev.Descriptor.Generic;
+
+namespace Descriptor.Formatters
+{
+    public abstract class AbstractFormatter
+    {
+        protected AbstractFormatter()
+        {
+            descriptors = new List<IDescriptor<IDescriptorContainer>>();
+        }
+
+        protected ICollection<IDescriptor<IDescriptorContainer>> descriptors { get; private set; }
+
+        public void AddDescriptor(IDescriptor<IDescriptorContainer> descriptor)
+        {
+            descriptors.Add(descriptor);
+        }
+
+        public abstract object Format();
+    }
+}

--- a/src/Descriptor.Formatters/Descriptor.Formatters.csproj
+++ b/src/Descriptor.Formatters/Descriptor.Formatters.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F46349B3-DD54-4504-976E-354D0799448A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>RimDev.Descriptor.Formatters</RootNamespace>
+    <AssemblyName>RimDev.Descriptor.Formatters</AssemblyName>
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AbstractFormatter.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Descriptor\Descriptor.csproj">
+      <Project>{09569c4c-7757-4b8e-b286-42e4571ee60b}</Project>
+      <Name>Descriptor</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Descriptor.Formatters/Properties/AssemblyInfo.cs
+++ b/src/Descriptor.Formatters/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Descriptor.Formatters")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Ritter Insurance Marketing, Inc.")]
+[assembly: AssemblyProduct("Descriptor.Formatters")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("71f11470-33c6-435a-a80f-3dc320c26763")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/Descriptor/Generic/AbstractDescriptor`1.cs
+++ b/src/Descriptor/Generic/AbstractDescriptor`1.cs
@@ -16,7 +16,7 @@ namespace RimDev.Descriptor.Generic
         }
 
         public TInstanceContainer Instance { get; private set; }
-        protected ICollection<object> Methods { get; private set; }
+        public ICollection<object> Methods { get; private set; }
 
         protected MemberInfo ExtractMethodInfoFromUnaryExpression(
             UnaryExpression expression)


### PR DESCRIPTION
Formatters will take raw descriptor-data and turn it into something useful.
Currently, the only formatter included is JSON. This leverages JSON.NET and comes in two versions: straight-serialization and one for WebApi, which changes the descriptor's `uri` property to `href`.