### PR TITLE
added an extension point for descriptor creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,8 @@ _TeamCity*
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
+*ncrunchproject
+*ncrunchsolution
 
 # MightyMoose
 *.mm.*

--- a/src/Descriptor/AssemblyScanner.cs
+++ b/src/Descriptor/AssemblyScanner.cs
@@ -17,7 +17,7 @@ namespace RimDev.Descriptor
 
         private readonly IEnumerable<Type> scannerTypes;
 
-        private Func<Type, IDescriptor<IDescriptorContainer>> DescriptorActivator { get; set; }
+        public Func<Type, IDescriptor<IDescriptorContainer>> DescriptorActivator { get; private set; }
 
         public static AssemblyScanner FindDescriptorsInAssembly(Assembly assembly)
         {

--- a/src/Descriptor/AssemblyScanner.cs
+++ b/src/Descriptor/AssemblyScanner.cs
@@ -17,7 +17,7 @@ namespace RimDev.Descriptor
 
         private readonly IEnumerable<Type> scannerTypes;
 
-        public Func<Type, IDescriptor<IDescriptorContainer>> DescriptorActivator { get; set; }
+        private Func<Type, IDescriptor<IDescriptorContainer>> DescriptorActivator { get; set; }
 
         public static AssemblyScanner FindDescriptorsInAssembly(Assembly assembly)
         {
@@ -31,6 +31,7 @@ namespace RimDev.Descriptor
 
         public AssemblyScanner SetActivator(Func<Type, IDescriptor<IDescriptorContainer>> activator)
         {
+            if (activator == null) throw new ArgumentNullException("activator");
             DescriptorActivator = activator;
             return this;
         }

--- a/tests/Descriptor.Tests/AssemblyScannerTests.cs
+++ b/tests/Descriptor.Tests/AssemblyScannerTests.cs
@@ -54,6 +54,12 @@ namespace RimDev.Descriptor.Tests
             Assert.Equal(1, count);
         }
 
+        [Fact]
+        public void Should_throw_if_activator_is_null()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AssemblyScanner(Enumerable.Empty<Type>()).SetActivator(null));
+        }
+
         public class TestDescriptor : IDescriptor<IDescriptorContainer>
         {
             public IDescriptorContainer Instance

--- a/tests/Descriptor.Tests/AssemblyScannerTests.cs
+++ b/tests/Descriptor.Tests/AssemblyScannerTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using RimDev.Descriptor.Generic;
 using Xunit;
 
-namespace RimDev.Descriptor.Tests.Generic
+namespace RimDev.Descriptor.Tests
 {
     public class AssemblyScannerTests
     {

--- a/tests/Descriptor.Tests/Descriptor.Tests.csproj
+++ b/tests/Descriptor.Tests/Descriptor.Tests.csproj
@@ -49,7 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Generic\AssemblyScannerTests.cs" />
+    <Compile Include="AssemblyScannerTests.cs" />
     <Compile Include="Generic\MethodDescriptorContainer`1.cs" />
     <Compile Include="Generic\DescriptorContainer`1Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/Descriptor.Tests/Descriptor.Tests.csproj
+++ b/tests/Descriptor.Tests/Descriptor.Tests.csproj
@@ -49,6 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Generic\AssemblyScannerTests.cs" />
     <Compile Include="Generic\MethodDescriptorContainer`1.cs" />
     <Compile Include="Generic\DescriptorContainer`1Tests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/Descriptor.Tests/Generic/AssemblyScannerTests.cs
+++ b/tests/Descriptor.Tests/Generic/AssemblyScannerTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Linq;
+using RimDev.Descriptor.Generic;
+using Xunit;
+
+namespace RimDev.Descriptor.Tests.Generic
+{
+    public class AssemblyScannerTests
+    {
+        [Fact]
+        public void Should_instantiate_assembly_scanner()
+        {
+            var scanner = new AssemblyScanner(new Type[0]);
+            Assert.NotNull(scanner);
+        }
+
+        [Fact]
+        public void Should_have_a_default_activator()
+        {
+            var scanner = new AssemblyScanner(new Type[0]);
+            Assert.NotNull(scanner.DescriptorActivator);
+        }
+
+        [Fact]
+        public void Should_be_able_to_find_descriptors_in_asembly()
+        {
+            var scanner = AssemblyScanner.FindDescriptorsInAssemblyContaining<TestDescriptor>();
+            Assert.Equal(1, scanner.Count());
+        }
+
+        [Fact]
+        public void Should_be_able_to_foreach()
+        {
+            var scanner = AssemblyScanner.FindDescriptorsInAssemblyContaining<TestDescriptor>();
+            var count = 0;
+
+            scanner.ForEach(x => count++);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public void Should_be_able_to_set_activator()
+        {
+            var count = 0;
+            var scanner = AssemblyScanner
+                .FindDescriptorsInAssemblyContaining<TestDescriptor>()
+                .SetActivator(t =>
+                {
+                    count++;
+                    return Activator.CreateInstance(t) as IDescriptor<IDescriptorContainer>;
+                }).ToList();
+
+            Assert.Equal(1, count);
+        }
+
+        public class TestDescriptor : IDescriptor<IDescriptorContainer>
+        {
+            public IDescriptorContainer Instance
+            {
+                get { return new TestDescriptorContainer(); }
+            }
+        }
+    }
+
+    public class TestDescriptorContainer : IDescriptorContainer
+    {
+        public string Name
+        {
+            get { return "Test"; }
+        }
+    }
+}


### PR DESCRIPTION
this will allow applications to create descriptors any method they see
fit. It will default to .NET's Activator.CreateInstance, but can be
changed to use an IoC container that may inject other dependencies. This
allows the injection of HttpContext, Databases, etc. Awesome!

Also added a few tests around the AssemblyScanner.