### PR TITLE
Remove descriptor's generic constraint

### DIFF
--- a/src/Descriptor.Http/HttpDescriptor.cs
+++ b/src/Descriptor.Http/HttpDescriptor.cs
@@ -5,7 +5,6 @@ using RimDev.Descriptor.Http.Generic;
 namespace RimDev.Descriptor.Http
 {
     public class HttpDescriptor<TClass> : Descriptor<TClass>
-        where TClass : class, new()
     {
         public HttpDescriptor(
             string name = null,

--- a/src/Descriptor/Descriptor.cs
+++ b/src/Descriptor/Descriptor.cs
@@ -6,7 +6,6 @@ using RimDev.Descriptor.Generic;
 namespace RimDev.Descriptor
 {
     public class Descriptor<TClass> : AbstractDescriptor<TClass, DescriptorContainer<TClass>>
-        where TClass : class, new()
     {
         public Descriptor(
             string name = null,

--- a/src/Descriptor/Generic/AbstractDescriptor`1.cs
+++ b/src/Descriptor/Generic/AbstractDescriptor`1.cs
@@ -6,7 +6,6 @@ using RimDev.Descriptor.Helpers;
 namespace RimDev.Descriptor.Generic
 {
     public abstract class AbstractDescriptor<TClass, TInstanceContainer> : IDescriptor<TInstanceContainer>
-        where TClass : class, new()
         where TInstanceContainer : class, IDescriptorContainer, new()
     {
         public AbstractDescriptor()


### PR DESCRIPTION
Previous behavior tried to limit types to classes and did so by requiring a parameter-less constructor.
However, this is proving limiting for users who want to use the library, but leverage DI and therefore do not have parameter-less constructors.
And having this constructor which does nothing seems superfluous.
This change is backwards compatible as no implementation changes were needed.

Related to #18.