### PR TITLE
Update method parameter-handler to use full-path of expression as name

### DIFF
--- a/src/Descriptor/Generic/MethodDescriptorContainer`1.cs
+++ b/src/Descriptor/Generic/MethodDescriptorContainer`1.cs
@@ -18,10 +18,13 @@ namespace RimDev.Descriptor.Generic
             string description = null,
             string type = null)
         {
+            // We want to get the full path of the expression.
+            var name = ((MemberExpression)parameter.Body).ToString();
+
             Parameters.Add(new DescriptorContainer<T>()
             {
                 Description = description,
-                Name = ((MemberExpression)parameter.Body).Member.Name,
+                Name = name.Substring(name.IndexOf('.') + 1),
                 Type = type
             });
 

--- a/tests/Descriptor.Tests/Generic/MethodDescriptorContainer`1.cs
+++ b/tests/Descriptor.Tests/Generic/MethodDescriptorContainer`1.cs
@@ -118,10 +118,34 @@ namespace RimDev.Descriptor.Tests.Generic
                 Assert.Equal("type", parameter.Type);
             }
 
+            [Fact]
+            public void Should_return_nested_instance_with_set_parameter()
+            {
+                var sut = new MethodDescriptorContainer<TestParameter>();
+
+                var @return = sut.Parameter(x => x.Eyes.Color, "description", "type");
+
+                Assert.NotNull(@return);
+
+                var parameter = @return.Parameters.FirstOrDefault();
+
+                Assert.NotNull(parameter);
+                Assert.Equal("Eyes.Color", parameter.Name);
+                Assert.Equal("description", parameter.Description);
+                Assert.Equal("type", parameter.Type);
+            }
+
             private class TestParameter
             {
                 public string FirstName { get; set; }
                 public string LastName { get; set; }
+
+                public Eye Eyes { get; set; }
+
+                public class Eye
+                {
+                    public string Color { get; set; }
+                }
             }
         }
     }


### PR DESCRIPTION
Previous behavior only used parameter-name.