### PR TITLE
Increment NuGet-version based on support for full-parameter path-name

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>1</MinorVersion>
-    <PatchVersion>3</PatchVersion>
+    <PatchVersion>4</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Descriptor.Http/Generics/HttpMethodDescriptorContainer`1.cs
+++ b/src/Descriptor.Http/Generics/HttpMethodDescriptorContainer`1.cs
@@ -18,10 +18,13 @@ namespace RimDev.Descriptor.Http.Generic
             string description = null,
             string type = null)
         {
+            // We want to get the full path of the expression.
+            var name = ((MemberExpression)parameter.Body).ToString();
+
             Parameters.Add(new HttpDescriptorContainer<T>()
             {
                 Description = description,
-                Name = ((MemberExpression)parameter.Body).Member.Name,
+                Name = name.Substring(name.IndexOf('.') + 1),
                 Type = type
             });
 


### PR DESCRIPTION
Previous behavior only used parameter-name.
Also update NuGet-version.