### PR TITLE
Added the ability to specify 'required' parameters

### DIFF
--- a/src/Descriptor.Http/Generics/HttpMethodDescriptorContainer`1.cs
+++ b/src/Descriptor.Http/Generics/HttpMethodDescriptorContainer`1.cs
@@ -16,7 +16,8 @@ namespace RimDev.Descriptor.Http.Generic
         public HttpMethodDescriptorContainer<T> Parameter<TProperty>(
             Expression<Func<T, TProperty>> parameter,
             string description = null,
-            string type = null)
+            string type = null,
+            bool? required = null)
         {
             // We want to get the full path of the expression.
             var name = ((MemberExpression)parameter.Body).ToString();
@@ -25,7 +26,8 @@ namespace RimDev.Descriptor.Http.Generic
             {
                 Description = description,
                 Name = name.Substring(name.IndexOf('.') + 1),
-                Type = type
+                Type = type,
+                Required = required
             });
 
             return this;

--- a/src/Descriptor/Generic/DescriptorContainer`1.cs
+++ b/src/Descriptor/Generic/DescriptorContainer`1.cs
@@ -1,6 +1,4 @@
-﻿using System.Security.Policy;
-
-namespace RimDev.Descriptor.Generic
+﻿namespace RimDev.Descriptor.Generic
 {
     public class DescriptorContainer<T> : IDescriptorContainer
     {

--- a/src/Descriptor/Generic/DescriptorContainer`1.cs
+++ b/src/Descriptor/Generic/DescriptorContainer`1.cs
@@ -1,10 +1,13 @@
-﻿namespace RimDev.Descriptor.Generic
+﻿using System.Security.Policy;
+
+namespace RimDev.Descriptor.Generic
 {
     public class DescriptorContainer<T> : IDescriptorContainer
     {
         public virtual string Description { get; set; }
         public virtual string Name { get; set; }
         public virtual string Type { get; set; }
+        public virtual bool? Required { get; set; }
 
         public DescriptorContainer<T> SetDescription(string description)
         {
@@ -23,6 +26,13 @@
         public DescriptorContainer<T> SetType(string type)
         {
             Type = type;
+
+            return this;
+        }
+
+        public DescriptorContainer<T> SetRequired(bool required)
+        {
+            Required = required;
 
             return this;
         }

--- a/src/Descriptor/Generic/MethodDescriptorContainer`1.cs
+++ b/src/Descriptor/Generic/MethodDescriptorContainer`1.cs
@@ -16,7 +16,8 @@ namespace RimDev.Descriptor.Generic
         public MethodDescriptorContainer<T> Parameter<TProperty>(
             Expression<Func<T, TProperty>> parameter,
             string description = null,
-            string type = null)
+            string type = null,
+            bool? required = null)
         {
             // We want to get the full path of the expression.
             var name = ((MemberExpression)parameter.Body).ToString();
@@ -25,7 +26,8 @@ namespace RimDev.Descriptor.Generic
             {
                 Description = description,
                 Name = name.Substring(name.IndexOf('.') + 1),
-                Type = type
+                Type = type,
+                Required = required
             });
 
             return this;

--- a/tests/Descriptor.Tests/Generic/MethodDescriptorContainer`1.cs
+++ b/tests/Descriptor.Tests/Generic/MethodDescriptorContainer`1.cs
@@ -135,6 +135,54 @@ namespace RimDev.Descriptor.Tests.Generic
                 Assert.Equal("type", parameter.Type);
             }
 
+            [Fact]
+            public void Should_return_required_as_null_by_default()
+            {
+                var sut = new MethodDescriptorContainer<TestParameter>();
+
+                var @return = sut.Parameter(x => x.Eyes.Color, "description", "type");
+                var parameter = @return.Parameters.FirstOrDefault();
+
+                Assert.Null(parameter.Required);
+            }
+
+            [Fact]
+            public void Should_return_required_as_true_when_set()
+            {
+                var sut = new MethodDescriptorContainer<TestParameter>();
+
+                var @return = sut.Parameter(x => x.Eyes.Color, "description", "type", true);
+                var parameter = @return.Parameters.FirstOrDefault();
+
+                Assert.NotNull(parameter.Required);
+                Assert.True(parameter.Required.Value);
+            }
+
+            [Fact]
+            public void Should_return_required_as_false_when_set()
+            {
+                var sut = new MethodDescriptorContainer<TestParameter>();
+
+                var @return = sut.Parameter(x => x.Eyes.Color, "description", "type", false);
+                var parameter = @return.Parameters.FirstOrDefault();
+
+                Assert.NotNull(parameter.Required);
+                Assert.False(parameter.Required.Value);
+            }
+
+            [Fact]
+            public void Should_be_able_to_set_required_via_method()
+            {
+                var sut = new MethodDescriptorContainer<TestParameter>();
+
+                var parameter = sut
+                    .Parameter(x => x.Eyes.Color, "description", "type")
+                    .SetRequired(true);
+
+                Assert.NotNull(parameter.Required);
+                Assert.True(parameter.Required.Value);
+            }
+
             private class TestParameter
             {
                 public string FirstName { get; set; }


### PR DESCRIPTION
Required parameters are a requested feature by Descriptor users. This
commit allows users to opt in to saying if a field is required or not.
This means required can be in three states: null, true, false. This was
done to support backward compatibility and not confuse implementations
in the wild.

#23