### PR TITLE
Allow Newtonsoft.Json v7 in RimDev.Descriptor.Formatters.Json

### DIFF
--- a/build/Build.Version.targets
+++ b/build/Build.Version.targets
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
     <MinorVersion>2</MinorVersion>
-    <PatchVersion>0</PatchVersion>
+    <PatchVersion>1</PatchVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Descriptor.Formatters.Json/Descriptor.Formatters.Json.nuspec
+++ b/src/Descriptor.Formatters.Json/Descriptor.Formatters.Json.nuspec
@@ -13,7 +13,7 @@
     <dependencies>
       <dependency id="RimDev.Descriptor" version="$version$" />
       <dependency id="RimDev.Descriptor.Formatters" version="$version$" />
-      <dependency id="Newtonsoft.Json" version="[6,7)" />
+      <dependency id="Newtonsoft.Json" version="[6,8)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Allow Newtonsoft.Json to be upgraded to v7 in projects that use the **RimDev.Descriptor.Formatters.Json** package.

This releases version **0.2.1**.